### PR TITLE
Adding spring actuator endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.2.RELEASE</version>
+		<version>2.1.6.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
@@ -38,7 +38,7 @@
 			<name>Manuel Bernal-Llinares</name>
 			<email>mbdebian@gmail.com</email>
 			<organization>EMBL-European Bioinformatics Institute</organization>
-			<organizationUrl>http://ebi.ac.uk/</organizationUrl>
+			<organizationUrl>https://ebi.ac.uk/</organizationUrl>
 			<timezone>Europe/London</timezone>
 			<roles>
 				<role>architect</role>
@@ -115,6 +115,21 @@
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-chrome-driver</artifactId>
 			<version>3.14.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
     </dependencies>
 

--- a/src/main/java/org/identifiers/cloud/ws/metadata/api/controllers/HealthApiController.java
+++ b/src/main/java/org/identifiers/cloud/ws/metadata/api/controllers/HealthApiController.java
@@ -2,6 +2,7 @@ package org.identifiers.cloud.ws.metadata.api.controllers;
 
 import org.identifiers.cloud.ws.metadata.api.models.HealthApiModel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,6 +16,9 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("healthApi")
+@Deprecated
+@ConditionalOnProperty(value = "management.endpoint.health.enabled",
+    matchIfMissing = true, havingValue = "false")
 public class HealthApiController {
     @Autowired
     private HealthApiModel model;

--- a/src/main/java/org/identifiers/cloud/ws/metadata/api/models/HealthApiModel.java
+++ b/src/main/java/org/identifiers/cloud/ws/metadata/api/models/HealthApiModel.java
@@ -1,5 +1,7 @@
 package org.identifiers.cloud.ws.metadata.api.models;
 
+import org.identifiers.cloud.ws.metadata.api.controllers.HealthApiController;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -13,6 +15,8 @@ import java.util.UUID;
  * ---
  */
 @Component
+@Deprecated
+@ConditionalOnBean(HealthApiController.class)
 public class HealthApiModel {
     private static String runningSessionId = UUID.randomUUID().toString();
 

--- a/src/main/java/org/identifiers/cloud/ws/metadata/configuration/AuthorizationConfiguration.java
+++ b/src/main/java/org/identifiers/cloud/ws/metadata/configuration/AuthorizationConfiguration.java
@@ -1,0 +1,37 @@
+package org.identifiers.cloud.ws.metadata.configuration;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+@EnableWebSecurity
+public class AuthorizationConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Value("${org.identifiers.cloud.ws.metadata.requiredrole}")
+    String requiredRole;
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        String aExp = String.format(
+                "isAuthenticated() and principal.claims['realm_access']['roles'].contains('%s')",
+                requiredRole
+        );
+
+        http.authorizeRequests()
+                .antMatchers(HttpMethod.POST, "/getMetadataForUrl*").permitAll()
+                .antMatchers("/actuator").access(aExp)
+                .antMatchers("/actuator/loggers/**").access(aExp)
+                .antMatchers("/actuator/health/**").permitAll()
+                .antMatchers(HttpMethod.GET, "/**").permitAll()
+            .and()
+                .csrf().disable()
+                .logout().disable()
+                .formLogin().disable()
+                .anonymous().and()
+                .oauth2ResourceServer().jwt();
+    }
+}

--- a/src/main/java/org/identifiers/cloud/ws/metadata/daemons/indicators/MetadataCollectorIndicator.java
+++ b/src/main/java/org/identifiers/cloud/ws/metadata/daemons/indicators/MetadataCollectorIndicator.java
@@ -1,0 +1,23 @@
+package org.identifiers.cloud.ws.metadata.daemons.indicators;
+
+import org.identifiers.cloud.ws.metadata.daemons.MetadataCollector;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnEnabledHealthIndicator("metadata-collector")
+public class MetadataCollectorIndicator implements HealthIndicator {
+    @Autowired
+    MetadataCollector metadataCollector;
+
+    @Override
+    public Health health() {
+        if (metadataCollector.isShutdown())
+            return Health.down().build();
+        else
+            return Health.up().build();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,37 @@ org.identifiers.cloud.ws.metadata.backend.data.channel.key.metadataextractionres
 org.identifiers.cloud.ws.metadata.backend.data.queue.key.metadataextractionrequest=${WS_METADATA_CONFIG_BACKEND_DATA_QUEUE_KEY_METADATA_EXTRACTION_REQUEST:metadataQueueMetadataExtractionRequest}
 # Chromedriver
 org.identifiers.cloud.ws.metadata.backend.selenium.driver.chrome.path.bin=${WS_METADATA_CONFIG_BACKEND_SELENIUM_DRIVER_CHROME_PATH_BIN:bin/selenium/chromedriver-mac}
+
+org.identifiers.cloud.ws.metadata.requiredrole=${WS_METADATA_CONFIG_BACKEND_REQUIRED_ROLE:chad}
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${WS_METADATA_CONFIG_BACKEND_SERVICE_JWT_ISSUERURI:http://localkeycloak:8080/auth/realms/scratchpad}
+
+### Spring actuators
+management.endpoints.jmx.exposure.exclude=*
+management.endpoint.loggers.enabled=true
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=when_authorized
+
+management.endpoints.web.exposure.include=loggers,health
+
+# Deactivations for peace of mind - likely unnecessary
+management.endpoint.auditevents.enabled=false
+management.endpoint.beans.enabled=false
+management.endpoint.caches.enabled=false
+management.endpoint.conditions.enabled=false
+management.endpoint.configprops.enabled=false
+management.endpoint.env.enabled=false
+management.endpoint.flyway.enabled=false
+management.endpoint.httptrace.enabled=false
+management.endpoint.info.enabled=false
+management.endpoint.integrationgraph.enabled=false
+management.endpoint.liquibase.enabled=false
+management.endpoint.metrics.enabled=false
+management.endpoint.mappings.enabled=false
+management.endpoint.scheduledtasks.enabled=false
+management.endpoint.sessions.enabled=false
+management.endpoint.shutdown.enabled=false
+management.endpoint.threaddump.enabled=false
+management.endpoint.heapdump.enabled=false
+management.endpoint.jolokia.enabled=false
+management.endpoint.logfile.enabled=false
+management.endpoint.prometheus.enabled=false


### PR DESCRIPTION
Replaced legacy health checkers for spring endpoint health check with custom indicators for the thread; Loggers endpoint enabled for production debug when needed; Added spring security for only authenticated users to access loggers actuator
